### PR TITLE
chore(k8s): upgrade kubernetes to v1.34.3 and scale traefik for HA

### DIFF
--- a/ansible/kubernetes/group_vars/all/all.yml
+++ b/ansible/kubernetes/group_vars/all/all.yml
@@ -1,5 +1,5 @@
 ---
-kube_version: 1.33.1
+kube_version: 1.34.3
 ## Directory where the binaries will be installed
 bin_dir: /usr/local/bin
 # Kube VIP
@@ -144,8 +144,7 @@ ntp_servers:
   - "2.pool.ntp.org iburst"
   - "3.pool.ntp.org iburst"
 
-## Used to control no_log attribute
-unsafe_show_logs: false
+unsafe_show_logs: true
 
 ## If enabled it will allow kubespray to attempt setup even if the distribution is not supported. For unsupported distributions this can lead to unexpected failures in some cases.
 allow_unsupported_distribution_setup: false

--- a/kubernetes/argocd/argocd-app/stateless/traefik/values.yaml
+++ b/kubernetes/argocd/argocd-app/stateless/traefik/values.yaml
@@ -3,7 +3,7 @@
 deployment:
   enabled: true
   kind: Deployment
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 3
   additionalVolumes:
   - name: crowdsec-lapi-key
@@ -612,7 +612,7 @@ persistence:
   storageClass: "juicefs-sc-cloudflare-r2"
   name: data
   existingClaim: ""
-  accessMode: ReadWriteOnce
+  accessMode: ReadWriteMany
   size: 128Mi
   volumeName: ""
   path: /data


### PR DESCRIPTION
- ansible: bump `kube_version` from 1.33.1 to 1.34.3
- ansible: update kubespray submodule pointer
- ansible: set `unsafe_show_logs` to true for debugging
- traefik: scale deployment replicas from 1 to 2
- traefik: change persistence accessMode from ReadWriteOnce to ReadWriteMany to support multiple replicas on JuiceFS